### PR TITLE
libbpf: update libbpf submodule

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -63,7 +63,7 @@ json2c: json2c.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
 #LDFLAGS ?= -L$(LIBKEFIR_DIR)/build -L$(LIBBPF_DIR)
 #LIBS += -lkefir -lbpf
 #simple_filter_test: simple_filter_test.c cl_options.c
-#	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $LIBS)
+#	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LIBS)
 
 $(LIBBPF_OBJECT): $(LIBKEFIR_OBJECT)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -60,9 +60,10 @@ json2c: json2c.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
 ## Build with shared library (.so) instead of static one (.a)
 ## Requires installing the libraries first
 ##
-#LDFLAGS ?= -L$(LIBKEFIR_DIR)/build -L$(LIBBPF_DIR)
-#simple_filter_test: simple_filter_test.c cl_options.c
-#	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lkefir -lbpf -lelf -lz
+LDFLAGS ?= -L$(LIBKEFIR_DIR)/build -L$(LIBBPF_DIR)
+LIBS += -lkefir -lbpf
+simple_filter_test: simple_filter_test.c cl_options.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $LIBS)
 
 $(LIBBPF_OBJECT): $(LIBKEFIR_OBJECT)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -60,10 +60,10 @@ json2c: json2c.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
 ## Build with shared library (.so) instead of static one (.a)
 ## Requires installing the libraries first
 ##
-LDFLAGS ?= -L$(LIBKEFIR_DIR)/build -L$(LIBBPF_DIR)
-LIBS += -lkefir -lbpf
-simple_filter_test: simple_filter_test.c cl_options.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $LIBS)
+#LDFLAGS ?= -L$(LIBKEFIR_DIR)/build -L$(LIBBPF_DIR)
+#LIBS += -lkefir -lbpf
+#simple_filter_test: simple_filter_test.c cl_options.c
+#	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $LIBS)
 
 $(LIBBPF_OBJECT): $(LIBKEFIR_OBJECT)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -35,6 +35,8 @@ EXTRA_WARNINGS += -Wno-switch-enum
 CFLAGS ?= -g -Wall -Wextra -Wpedantic $(EXTRA_WARNINGS)
 CFLAGS += -I$(HDR_DIR)
 
+LIBS = -lelf -lz
+
 all: $(EXAMPLES)
 
 $(HDR_DIR)/kefir/libkefir.h:
@@ -44,23 +46,23 @@ $(HDR_DIR)/kefir/libkefir.h:
 $(addsuffix .o,$(EXAMPLES)): $(HDR_DIR)/kefir/libkefir.h
 
 simple_filter: simple_filter.o cl_options.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 simple_filter_steps: simple_filter_steps.o cl_options.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 tcflower2json: tcflower2json.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 json2c: json2c.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 ## Build with shared library (.so) instead of static one (.a)
 ## Requires installing the libraries first
 ##
 #LDFLAGS ?= -L$(LIBKEFIR_DIR)/build -L$(LIBBPF_DIR)
 #simple_filter_test: simple_filter_test.c cl_options.c
-#	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lkefir -lbpf -lelf
+#	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lkefir -lbpf -lelf -lz
 
 $(LIBBPF_OBJECT): $(LIBKEFIR_OBJECT)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -44,16 +44,16 @@ $(HDR_DIR)/kefir/libkefir.h:
 $(addsuffix .o,$(EXAMPLES)): $(HDR_DIR)/kefir/libkefir.h
 
 simple_filter: simple_filter.o cl_options.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
 
 simple_filter_steps: simple_filter_steps.o cl_options.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
 
 tcflower2json: tcflower2json.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
 
 json2c: json2c.o $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
 
 ## Build with shared library (.so) instead of static one (.a)
 ## Requires installing the libraries first

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,7 @@ $(HDR_DIR)/bpf/libbpf.h:
 $(OBJECTS): $(HDR_DIR)/bpf/libbpf.h $(HDR_DIR)/kefir/libkefir.h
 
 tester: $(OBJECTS) $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf
+	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
 
 $(LIBBPF_OBJECT): $(LIBKEFIR_OBJECT)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,6 +15,8 @@ OBJECTS := $(patsubst %.c,%.o,$(OBJECTS))
 CFLAGS ?= -g -Wall -Wextra -Wpedantic
 CFLAGS += -I$(HDR_DIR)
 
+LIBS = -lelf -lz
+
 default: tester
 
 $(HDR_DIR)/kefir/libkefir.h:
@@ -28,7 +30,7 @@ $(HDR_DIR)/bpf/libbpf.h:
 $(OBJECTS): $(HDR_DIR)/bpf/libbpf.h $(HDR_DIR)/kefir/libkefir.h
 
 tester: $(OBJECTS) $(LIBKEFIR_OBJECT) $(LIBBPF_OBJECT)
-	$(CC) $(CFLAGS) -o $@ $^ -lelf -lz
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 $(LIBBPF_OBJECT): $(LIBKEFIR_OBJECT)
 


### PR DESCRIPTION
Update to current head, since the following commit is necessary in oder to build correctly:
https://github.com/libbpf/libbpf/commit/63a3bdf23a3f4c6a7b9e66d53d8137dba5667c98

Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>